### PR TITLE
Update action to use dynamic Dockerhub username

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,4 +24,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: diouxx/glpi:latest
+          tags: {{ secrets.DOCKER_HUB_USERNAME }}/glpi:latest


### PR DESCRIPTION
Action now uses DOCKER_HUB_USERNAME for the docker repo, so forkers don't need to make a code change to publish their own version of the image